### PR TITLE
Fixed Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SOC_DIR = iMX8M
 endif
 SOC_DIR ?= $(SOC)
 
-ifdef $(DTBS)
+ifdef DTBS
 EXTRAS := dtbs=$(DTBS)
 endif
 


### PR DESCRIPTION
'ifdef' statement takes the name of a variable, not a reference (see GNU Make manual)